### PR TITLE
[fix] Noto Sans KR 폰트가 웹에서 반영되지 않는 이슈 수정 #5

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,12 +1,16 @@
 import type { Metadata } from 'next';
 import { Noto_Sans_KR } from 'next/font/google';
-import './globals.css';
-import QueryProvider from './providers/QueryProvider';
+
+import QueryProvider from '../providers/QueryProvider';
+
+import '../styles/globals.css';
 
 const notoSansKR = Noto_Sans_KR({
   variable: '--font-noto-sans',
   subsets: ['latin'],
   weight: ['400', '500', '700'],
+  display: 'swap',
+  fallback: ['system-ui', 'arial'],
 });
 
 export const metadata: Metadata = {
@@ -14,12 +18,14 @@ export const metadata: Metadata = {
   description: '독특하고 재미있는 경매 시스템을 통해 중고 물품을 거래할 수 있는 플랫폼입니다.',
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <html lang="ko">
-      <body className={notoSansKR.variable}>
+    <html lang="ko" className={notoSansKR.variable}>
+      <body className="font-sans antialiased">
         <QueryProvider>{children}</QueryProvider>
       </body>
     </html>
   );
-}
+};
+
+export default RootLayout;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -7,6 +7,10 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  experimental: {
+    optimizePackageImports: ['@repo/ui'],
+  },
+  optimizeFonts: true, // 폰트 최적화
 };
 
 export default nextConfig;

--- a/apps/web/providers/QueryProvider.tsx
+++ b/apps/web/providers/QueryProvider.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useState } from 'react';
 
-export default function QueryProvider({ children }: { children: React.ReactNode }) {
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+const QueryProvider = ({ children }: { children: React.ReactNode }) => {
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -20,8 +21,11 @@ export default function QueryProvider({ children }: { children: React.ReactNode 
   return (
     <QueryClientProvider client={queryClient}>
       {children}
+
       {/* 개발 환경에서만 DevTools 표시 */}
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );
-}
+};
+
+export default QueryProvider;

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -1,6 +1,6 @@
 @import 'tailwindcss';
 @import '@repo/tailwind-config';
-@import '@repo/ui/styles.css';
+/* @import '@repo/ui/styles.css'; */
 
 :root {
   font-family: var(--font-noto-sans), sans-serif;

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -1,7 +1,2 @@
 @import 'tailwindcss';
 @import '@repo/tailwind-config';
-/* @import '@repo/ui/styles.css'; */
-
-:root {
-  font-family: var(--font-noto-sans), sans-serif;
-}

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -1,0 +1,3 @@
+@theme {
+  --font-sans: var(--font-noto-sans), system-ui, sans-serif;
+}

--- a/packages/ui/src/global.css
+++ b/packages/ui/src/global.css
@@ -1,8 +1,5 @@
 @import 'tailwindcss';
 
-/* 구글 폰트 임포트 */
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700;800&display=swap');
-
 @layer base {
   /* CSS 사용자 정의 속성 (CSS Variables) */
   :root {
@@ -36,9 +33,6 @@
     /* Disabled States */
     --color-disabled-bg: #f1eefe;
     --color-disabled-text: #656565;
-
-    /* Font Family */
-    --font-family-primary: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   }
 
   /* 기본 HTML 요소 스타일링 */


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

#5 

## 📋 작업 내용

노토산스 폰트가 web 렌더링 화면에서 적용되지 않는 이유 파악 및 적용

## 🔧 변경 사항

- app router 용도의 디렉토리와 구분하기 위해 router와 의존성이 없는 디렉토리는 app 바깥으로 이동
  - `apps/web/app/globals.css` -> `apps/web/styles/globals.css` 로 파일 위치 이동
  - `apps/web/app/providers/*` -> `apps/web/providers/*`로 파일 위치 이동
  
- globals.css 내부 수정 
  - globals.css가 참조하고 있지만 존재 하지 않은 `@repo/ui/styles.css` import 문구 제거
  - globals.css가 참조하고 있지만 존재 하지 않은 `@repo/tailwind-config` 내 `packgages.json`에서 정의하고 있는 `shared-styles.css` 파일 생성
    ```json
      {
      "name": "@repo/tailwind-config",
      "version": "0.0.0",
      "type": "module",
      "private": true,
      "exports": {
        ".": "./shared-styles.css", // 여기서 정의된 파일이 실존하지 않음.
        "./postcss": "./postcss.config.js"
      },
      "devDependencies": {
        "postcss": "^8.5.3",
        "tailwindcss": "^4.1.5"
      }
    }
    ```
- `shared-styles.css` 파일에서 기존 tailwindcss에서 사용하는 유틸클래스 `font-sans` 를 @theme 지시어를 통해 font-family 속성 값을 노토산스 변수로 적용되도록 커스텀하여 body에 font-sans 클래스 적용
    ```css
    @theme {
      --font-sans: var(--font-noto-sans), system-ui, sans-serif;
    }
    ```
    ```tsx
    // layout.tsx 

    const notoSansKR = Noto_Sans_KR({
      variable: '--font-noto-sans', 
      subsets: ['latin'],
      weight: ['400', '500', '700'],
      display: 'swap',
      fallback: ['system-ui', 'arial'],
    });
    
    const RootLayout = ({ children }: { children: React.ReactNode }) => {
      return (
        <html lang="ko" className={notoSansKR.variable}> // '--font-noto-sans' 전역 변수 적용
          <body className="font-sans"> // 커스텀한 유틸클래스 적용
            // 생략
          </body>
        </html>
      );
    };
    
    export default RootLayout;
    ```
- 최종 적용된 css 형태
    ```css
    :root {
      --font-noto-sans: 'Noto Sans KR'; 
    }
    body.font-sans {
      font-family: var(--font-noto-sans), system-ui, sans-serif;
    }
    ```


## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/693d2035-d6aa-4d37-ae3c-58b7d0396ebc)

## 📄 기타

**노토산스 폰트가 적용되지 않은 이유**

- web 디렉토리 내 globals.css 
  - 제대로 정의 되지 않은 import 문의 tailwindcss 규칙이 덮어씌어질 가능성으로 확인
  - 사용하지 않는 import 문만 제거해도 노토산스 폰트가 바로 적용 됨 
    ```css
    @import 'tailwindcss';
    /* @import '@repo/tailwind-config'; */
    /* @import '@repo/ui/styles.css'; */
    
    :root {
      font-family: var(--font-noto-sans), sans-serif;
    }
    ```
  - 이 경우 최종 css 적용 형태 
    ```css
    :root {
        --font-noto-sans: 'Noto Sans KR'; 
        font-family: var(--font-noto-sans), sans-serif;
     }
    ```
