### PR TITLE
[fix] eslint 가 수정된 파일 위치를 찾지 못하는 이슈를 해결하기 위한 lefthook.yml 파일 수정 #6

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,17 +6,17 @@ pre-commit:
 
     eslint-web:
       glob: 'apps/web/**/*.{js,ts,jsx,tsx}'
-      run: pnpm --filter=web exec eslint {staged_files} --fix && echo "ESLint ran on {staged_files}"
+      run: cd apps/web && pnpm exec eslint $(echo "{staged_files}" | sed 's|apps/web/||g') --fix && echo "ESLint ran on web files"
       stage_fixed: true
 
     eslint-docs:
       glob: 'apps/docs/**/*.{js,ts,jsx,tsx}'
-      run: pnpm --filter=docs exec eslint {staged_files} --fix && echo "ESLint ran on {staged_files}"
+      run: cd apps/docs && pnpm exec eslint $(echo "{staged_files}" | sed 's|apps/docs/||g') --fix && echo "ESLint ran on docs files"
       stage_fixed: true
 
     eslint-ui:
       glob: 'packages/ui/**/*.{js,ts,jsx,tsx}'
-      run: pnpm --filter=ui exec eslint {staged_files} --fix && echo "ESLint ran on {staged_files}"
+      run: cd packages/ui && pnpm exec eslint $(echo "{staged_files}" | sed 's|packages/ui/||g') --fix && echo "ESLint ran on ui files"
       stage_fixed: true
 
     prettier:
@@ -28,3 +28,4 @@ commit-msg:
   commands:
     lint-commit-msg:
       run: pnpm exec commitlint --edit {1}
+      

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,4 +28,3 @@ commit-msg:
   commands:
     lint-commit-msg:
       run: pnpm exec commitlint --edit {1}
-      


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

#6 

## 📋 작업 내용
- web 디렉토리 내 next js 의 app router 역할을 하는 app 디렉토리와 다른 파일들의 역할을 구분하기 위에 app 디렉토리 내부에 있는 globals.css 파일과 providers 디렉토리의 위치를 이동하는 과정에서 eslint 이슈 확인

  ![image](https://github.com/user-attachments/assets/134979de-a996-4546-9b26-7df79efdf3bd)

- 이슈의 원인은 lefthook.yml 파일에서 web 디렉토리로 위치를 이동한 상태에서 다시 'apps/web/**/*.{js,ts,jsx,tsx}' 파일을 찾도록 설정이 되어있기 때문이며 apps/web/apps/web 경로는 존재하지 않기 때문에 lefthook.yml 내용 수정
  ```yml
  eslint-web:
    glob: 'apps/web/**/*.{js,ts,jsx,tsx}'

    // 수정 전 
    run: pnpm --filter=web exec eslint {staged_files} --fix && echo "ESLint ran on {staged_files}"

    // 수정 후
    run: cd apps/web && pnpm exec eslint $(echo "{staged_files}" | sed 's|apps/web/||g') --fix && echo "ESLint ran on web files"

    stage_fixed: true
  ```

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [x] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
