### PR TITLE
[chore] turbo run storybook 실행 시 docs app의 스토리북이 실행되도록 설정 #29

### DIFF
--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -7,9 +7,8 @@ function getAbsolutePath(value: string): any {
 
 const config: StorybookConfig = {
   stories: [
-    '../stories/**/*.mdx',
-    '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../../../packages/ui/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    '../../../packages/ui/src/**/*.mdx',
   ],
   addons: [
     getAbsolutePath('@storybook/addon-onboarding'),

--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -9,6 +9,8 @@ const config: StorybookConfig = {
   stories: [
     '../../../packages/ui/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../../../packages/ui/src/**/*.mdx',
+    '../../../apps/web/components/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    '../../../apps/web/app/**/*.stories.@(js|jsx|mjs|ts|tsx)',
   ],
   addons: [
     getAbsolutePath('@storybook/addon-onboarding'),

--- a/apps/docs/.storybook/preview.ts
+++ b/apps/docs/.storybook/preview.ts
@@ -1,7 +1,7 @@
 import type { Preview } from '@storybook/nextjs';
 import '../stories/global-styles.css';
 import '@repo/ui/styles.css';
-import '../../../apps/web/app/globals.css';
+import '../../web/styles/globals.css';
 
 const preview: Preview = {
   parameters: {

--- a/apps/docs/.storybook/preview.ts
+++ b/apps/docs/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import type { Preview } from '@storybook/nextjs';
 import '../stories/global-styles.css';
+import '@repo/ui/styles.css';
 
 const preview: Preview = {
   parameters: {

--- a/apps/docs/.storybook/preview.ts
+++ b/apps/docs/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import type { Preview } from '@storybook/nextjs';
 import '../stories/global-styles.css';
 import '@repo/ui/styles.css';
+import '../../../apps/web/app/globals.css';
 
 const preview: Preview = {
   parameters: {

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -12,7 +12,8 @@
     "**/*.tsx",
     "next-env.d.ts",
     "next.config.ts",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".storybook/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -1,0 +1,24 @@
+import type { StorybookConfig } from '@storybook/nextjs';
+import { join, dirname } from 'path';
+
+function getAbsolutePath(value: string): any {
+  return dirname(require.resolve(join(value, 'package.json')));
+}
+
+const config: StorybookConfig = {
+  stories: [
+    '../components/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    '../app/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+  ],
+  addons: [
+    getAbsolutePath('@storybook/addon-onboarding'),
+    getAbsolutePath('@chromatic-com/storybook'),
+    getAbsolutePath('@storybook/addon-docs'),
+  ],
+  framework: {
+    name: getAbsolutePath('@storybook/nextjs'),
+    options: {},
+  },
+  staticDirs: ['../public'],
+};
+export default config;

--- a/apps/web/.storybook/preview.ts
+++ b/apps/web/.storybook/preview.ts
@@ -1,0 +1,16 @@
+import type { Preview } from '@storybook/nextjs';
+import '@repo/ui/styles.css';
+import '../app/globals.css';
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/apps/web/.storybook/preview.ts
+++ b/apps/web/.storybook/preview.ts
@@ -1,6 +1,6 @@
 import type { Preview } from '@storybook/nextjs';
 import '@repo/ui/styles.css';
-import '../app/globals.css';
+import '../styles/globals.css';
 
 const preview: Preview = {
   parameters: {

--- a/apps/web/components/login/LoginButton.stories.tsx
+++ b/apps/web/components/login/LoginButton.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import LoginButton from './LoginButton';
+
+const meta = {
+  title: 'Web App/Login/LoginButton',
+  component: LoginButton,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+로그인 페이지에서 사용되는 로그인 버튼 컴포넌트입니다.
+
+## 주요 기능
+- ✅ 로그인/회원가입 상태 전환
+- ✅ 폼 검증 상태에 따른 비활성화
+- ✅ 로딩 상태 표시
+- ✅ 접근성 지원
+        `,
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    isLogin: {
+      control: { type: 'boolean' },
+      description: '로그인 모드 여부',
+      table: {
+        defaultValue: { summary: 'true' },
+      },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: '버튼 비활성화 여부',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+    loading: {
+      control: { type: 'boolean' },
+      description: '로딩 상태 여부',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+  },
+} satisfies Meta<typeof LoginButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 로그인 버튼
+export const Login: Story = {
+  args: {
+    isLogin: true,
+    disabled: false,
+    loading: false,
+  },
+};
+
+// 회원가입 버튼
+export const SignUp: Story = {
+  args: {
+    isLogin: false,
+    disabled: false,
+    loading: false,
+  },
+};
+
+// 비활성화된 로그인 버튼
+export const LoginDisabled: Story = {
+  args: {
+    isLogin: true,
+    disabled: true,
+    loading: false,
+  },
+};
+
+// 로딩 중인 로그인 버튼
+export const LoginLoading: Story = {
+  args: {
+    isLogin: true,
+    disabled: false,
+    loading: true,
+  },
+};
+
+// 로딩 중인 회원가입 버튼
+export const SignUpLoading: Story = {
+  args: {
+    isLogin: false,
+    disabled: false,
+    loading: true,
+  },
+};
+
+// 모든 상태 비교
+export const AllStates: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold">로그인 버튼</h3>
+        <div className="flex gap-4">
+          <LoginButton isLogin={true} disabled={false} loading={false} />
+          <LoginButton isLogin={true} disabled={true} loading={false} />
+          <LoginButton isLogin={true} disabled={false} loading={true} />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold">회원가입 버튼</h3>
+        <div className="flex gap-4">
+          <LoginButton isLogin={false} disabled={false} loading={false} />
+          <LoginButton isLogin={false} disabled={true} loading={false} />
+          <LoginButton isLogin={false} disabled={false} loading={true} />
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: '로그인 버튼의 모든 상태를 한번에 비교해볼 수 있습니다.',
+      },
+    },
+  },
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint --max-warnings 0",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "storybook:dev": "storybook dev -p 6008",
+    "storybook:build": "storybook build"
   },
   "dependencies": {
     "@apps/docs": "workspace:*",
@@ -22,10 +24,14 @@
     "zod": "^3.25.67"
   },
   "devDependencies": {
+    "@chromatic-com/storybook": "^4",
     "@next/eslint-plugin-next": "^15.3.0",
     "@repo/eslint-config": "workspace:*",
     "@repo/tailwind-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
+    "@storybook/addon-docs": "^9.0.6",
+    "@storybook/addon-onboarding": "^9.0.6",
+    "@storybook/nextjs": "^9.0.6",
     "@tailwindcss/postcss": "^4.1.5",
     "@tanstack/react-query-devtools": "^5.80.7",
     "@types/node": "^22.15.3",
@@ -33,7 +39,9 @@
     "@types/react-dom": "^19.1.1",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.28.0",
+    "eslint-plugin-storybook": "^9.0.6",
     "postcss": "^8.5.3",
+    "storybook": "^9.0.6",
     "tailwindcss": "^4.1.5",
     "typescript": "5.8.2"
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "lint": "turbo run lint",
     "check-types": "turbo run check-types",
     "storybook": "turbo run storybook",
+    "storybook:ui": "turbo run storybook:dev --filter=@repo/ui",
+    "storybook:web": "turbo run storybook:dev --filter=web",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\""
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "check-types": "turbo run check-types",
+    "storybook": "turbo run storybook",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\""
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
     "dev:styles": "tailwindcss -i ./src/global.css -o ./dist/index.css --watch",
     "dev:components": "tsc --watch",
     "lint": "eslint src --max-warnings 0",
-    "storybook": "storybook dev -p 6006",
+    "storybook:dev": "storybook dev -p 6007",
     "build-storybook": "storybook build"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
         specifier: ^3.25.67
         version: 3.25.67
     devDependencies:
+      '@chromatic-com/storybook':
+        specifier: ^4
+        version: 4.0.0(storybook@9.0.8)
       '@next/eslint-plugin-next':
         specifier: ^15.3.0
         version: 15.3.3
@@ -202,6 +205,15 @@ importers:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      '@storybook/addon-docs':
+        specifier: ^9.0.6
+        version: 9.0.8(@types/react@19.1.7)(storybook@9.0.8)
+      '@storybook/addon-onboarding':
+        specifier: ^9.0.6
+        version: 9.0.8(storybook@9.0.8)
+      '@storybook/nextjs':
+        specifier: ^9.0.6
+        version: 9.0.8(esbuild@0.25.5)(next@15.3.3)(react-dom@19.1.0)(react@19.1.0)(storybook@9.0.8)(typescript@5.8.2)(webpack@5.99.9)
       '@tailwindcss/postcss':
         specifier: ^4.1.5
         version: 4.1.8
@@ -223,9 +235,15 @@ importers:
       eslint:
         specifier: ^9.28.0
         version: 9.28.0
+      eslint-plugin-storybook:
+        specifier: ^9.0.6
+        version: 9.0.6(eslint@9.28.0)(storybook@9.0.8)(typescript@5.8.2)
       postcss:
         specifier: ^8.5.3
         version: 8.5.4
+      storybook:
+        specifier: ^9.0.6
+        version: 9.0.8(@testing-library/dom@10.4.0)(prettier@3.5.3)
       tailwindcss:
         specifier: ^4.1.5
         version: 4.1.8

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,15 @@
     "dev": {
       "cache": false,
       "persistent": true
+    },
+    "storybook": {
+      "cache": false,
+      "persistent": true,
+      "dependsOn": ["^build"]
+    },
+    "storybook:dev": {
+      "cache": false,
+      "persistent": true
     }
   }
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- turbo run storybook 실행 시 수행되는 task가 없으므로 docs app의 스토리북이 실행되도록 설정 추가
  ![image](https://github.com/user-attachments/assets/a5506b94-3ac1-4f05-b9fc-a91cc9337efa)
- web app 내 스토리북 설치
- web app의 스토리북과 ui 패키지의 스토리북을 통합하도록 docs app 스토리북에 연결
- 렌더링 화면 이슈 해결

## 🔧 변경 사항

- [ ] 📃 README.md
- [x] 📦 package.json
- [ ] 🔥 파일 삭제
- [x] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

- turbo run storybook 실행 시 docs app의 스토리북이 실행된 화면
  ![image](https://github.com/user-attachments/assets/a6df53d5-8b1a-4c95-b654-72f7e7dd3bfa)

## 📄 기타

**루트에서 스토리북 실행 명령어**

- `turbo run storybook` 또는 `pnpm storybook` : docs app의 스토리북 실행 (web app, ui 패키지의 통합 문서)
- `pnpm storybook:web` : web app의 스토리북 실행
- `pnpm storybook:ui` : ui package의 스토리북 실행
