### PR TITLE
[chore] ui 패키지 내 절대경로 설정 #54

### DIFF
--- a/apps/web/app/(pages)/products/page.tsx
+++ b/apps/web/app/(pages)/products/page.tsx
@@ -1,4 +1,4 @@
-import { LabeledInput } from '@repo/ui/components/Input';
+import { LabeledInput } from '@repo/ui/components';
 
 const ProductsPage = () => {
   return (

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,6 +13,10 @@
       "types": "./dist/design-system/base-components/*/index.d.ts",
       "import": "./dist/design-system/base-components/*/index.js"
     },
+    "./components": {
+      "types": "./dist/design-system/base-components/*/index.d.ts",
+      "import": "./dist/design-system/base-components/*/index.js"
+    },
     "./*": {
       "types": "./dist/*.d.ts",
       "import": "./dist/*.js"

--- a/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
+++ b/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import Image from 'next/image';
 import { forwardRef } from 'react';
-import { cn } from '../../../utils/cn'; // 클래스명 유틸리티 함수
+import Image from 'next/image';
+import { cn } from '@/utils/cn';
 
 export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   src?: string; // 프로필 이미지 URL

--- a/packages/ui/src/design-system/base-components/Badge/Badge.tsx
+++ b/packages/ui/src/design-system/base-components/Badge/Badge.tsx
@@ -1,4 +1,4 @@
-import { cn } from '../../../utils/cn';
+import { cn } from '@/utils/cn';
 
 export interface BadgeProps {
   children: React.ReactNode;

--- a/packages/ui/src/design-system/base-components/Icons/Icon.tsx
+++ b/packages/ui/src/design-system/base-components/Icons/Icon.tsx
@@ -1,4 +1,4 @@
-import { cn } from '../../../utils/cn';
+import { cn } from '@/utils/cn';
 import { ICONS, IconName } from './assets/Icons';
 
 type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';

--- a/packages/ui/src/design-system/base-components/Input/Input.tsx
+++ b/packages/ui/src/design-system/base-components/Input/Input.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react';
-import { cn } from '../../../utils/cn';
+import { cn } from '@/utils/cn';
 
 export interface InputProps extends Omit<React.ComponentProps<'input'>, 'size'> {
   variant?: 'default' | 'error' | 'success';

--- a/packages/ui/src/design-system/base-components/Input/PasswordInput.tsx
+++ b/packages/ui/src/design-system/base-components/Input/PasswordInput.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useId } from 'react';
 import { Input, type InputProps } from './Input';
 import { PasswordToggle } from './components/PasswordToggle';
 import { useInputState } from './hooks/useInputState';
-import { cn } from '../../../utils/cn';
+import { cn } from '@/utils/cn';
 
 export interface PasswordInputProps extends Omit<InputProps, 'type'> {
   error?: boolean;

--- a/packages/ui/src/design-system/base-components/Input/components/PasswordToggle.tsx
+++ b/packages/ui/src/design-system/base-components/Input/components/PasswordToggle.tsx
@@ -1,5 +1,5 @@
 import { MdVisibility, MdVisibilityOff } from 'react-icons/md';
-import { cn } from '../../../../utils/cn';
+import { cn } from '@/utils/cn';
 
 export interface PasswordToggleProps {
   showPassword: boolean;

--- a/packages/ui/src/design-system/base-components/Label/Label.tsx
+++ b/packages/ui/src/design-system/base-components/Label/Label.tsx
@@ -1,4 +1,4 @@
-import { cn } from '../../../utils/cn';
+import { cn } from '@/utils/cn';
 
 export interface LabelProps {
   htmlFor: string;

--- a/packages/ui/src/design-system/base-components/index.ts
+++ b/packages/ui/src/design-system/base-components/index.ts
@@ -1,0 +1,7 @@
+export * from './Avatar';
+export * from './Badge';
+export * from './Card';
+export * from './FormMessage';
+export * from './Input';
+export * from './Label';
+export * from './Textarea';

--- a/packages/ui/src/design-system/design-token-stories/colors/PrimitiveColors.stories.tsx
+++ b/packages/ui/src/design-system/design-token-stories/colors/PrimitiveColors.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 import { colorTokens } from './generated-tokens';
-import { StoryPage, PageTitle, ColorPalette } from '../../../storybook-components';
+import { StoryPage, PageTitle, ColorPalette } from '@/storybook-components';
 
 const meta: Meta = {
   title: 'Design System/Design Tokens/Colors/Primitive Colors',

--- a/packages/ui/src/design-system/design-token-stories/colors/SemanticColors.stories.tsx
+++ b/packages/ui/src/design-system/design-token-stories/colors/SemanticColors.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 import { colorTokens, utilityColorCSSValue } from './generated-tokens';
-import { StoryPage, PageTitle, ColorList, ColorPalette } from '../../../storybook-components';
+import { StoryPage, PageTitle, ColorList, ColorPalette } from '@/storybook-components';
 
 const meta: Meta = {
   title: 'Design System/Design Tokens/Colors/Semantic Colors',

--- a/packages/ui/src/design-system/design-token-stories/colors/UtilityColors.stories.tsx
+++ b/packages/ui/src/design-system/design-token-stories/colors/UtilityColors.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 import { utilityColorCSSValue } from './generated-tokens';
-import { StoryPage, PageTitle, HowToUseClass, ColorList } from '../../../storybook-components';
+import { StoryPage, PageTitle, HowToUseClass, ColorList } from '@/storybook-components';
 
 const meta: Meta = {
   title: 'Design System/Design Tokens/Colors/Utility Colors',

--- a/packages/ui/src/storybook-components/Section.tsx
+++ b/packages/ui/src/storybook-components/Section.tsx
@@ -1,14 +1,12 @@
-import { cn } from "../utils/cn";
+import { cn } from '@/utils/cn';
 
 interface SectionProps {
-    children: React.ReactNode;
-    className?: string;
+  children: React.ReactNode;
+  className?: string;
 }
 
-const Section = ({children, className} : SectionProps) => (
-  <section className={cn('w-full flex flex-col gap-lg', className)}>
-    {children}
-  </section>
+const Section = ({ children, className }: SectionProps) => (
+  <section className={cn('w-full flex flex-col gap-lg', className)}>{children}</section>
 );
 
 export default Section;

--- a/packages/ui/src/storybook-components/StoryPage.tsx
+++ b/packages/ui/src/storybook-components/StoryPage.tsx
@@ -1,11 +1,11 @@
-import { cn } from "../utils/cn";
+import { cn } from '@/utils/cn';
 
 interface StoryPageProps {
-    children: React.ReactNode;
-    className?: string;
+  children: React.ReactNode;
+  className?: string;
 }
 
-const StoryPage = ({children, className} : StoryPageProps) => (
+const StoryPage = ({ children, className }: StoryPageProps) => (
   <main className={cn('flex flex-col gap-5xl w-full p-lg max-w-[1000px] mx-auto ', className)}>
     {children}
   </main>

--- a/packages/ui/src/utils/storybook/color-token-utils.ts
+++ b/packages/ui/src/utils/storybook/color-token-utils.ts
@@ -1,7 +1,7 @@
 import {
   primitiveColors,
   semanticColorCSSValues,
-} from '../../design-system/design-token-stories/colors/generated-tokens';
+} from '@/design-system/design-token-stories/colors/generated-tokens';
 
 // 색상 타입별 매핑
 const COLOR_TYPE_MAPPING = {

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "./src",
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["src", "**/*.cjs", "postcss.config.mjs", "postcss.config.js"],
   "exclude": ["dist", "build", "node_modules"]


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- UI 패키지 내 상대경로를 절대경로로 사용하도록 설정 추가
- web app에서 ui 패키지의 컴포넌트를 `@import { Input, Icon } from '@repo/ui/components'` 형태로 사용가능하도록 설정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
