### PR TITLE
[feat] 버튼 컴포넌트 생성

### DIFF
--- a/packages/ui/src/design-system/base-components/Button/Button.stories.tsx
+++ b/packages/ui/src/design-system/base-components/Button/Button.stories.tsx
@@ -1,0 +1,266 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import Button, { type ButtonProps } from './Button';
+
+const meta: Meta<ButtonProps> = {
+  title: 'Design System/Base Components/Button',
+  component: Button,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+공통 버튼 컴포넌트입니다.
+
+## 주요 기능
+- ✅ 6가지 미리 정의된 variant (Primary/Secondary/Danger의 Filled/Outlined 조합)
+- ✅ 3가지 크기 지원 (sm, md, lg)
+- ✅ 다양한 HTML 요소로 렌더링 가능 (button, a, div, span)
+- ✅ 전체 너비 및 비활성화 상태 지원
+- ✅ TailwindCSS 동적 클래스 최적화 적용
+
+## as prop 사용 가이드
+- **button**: 기본값, 일반적인 버튼 용도
+- **a**: 링크 기능이 필요한 경우
+- **div/span**: react-router-dom의 <Link>와 함께 사용할 때 <a> 태그 중복 방지를 위해 사용
+- Next.js의 <Link>는 자식이 <a> 태그일 경우 a 요소 중복이 자동 제거되므로 <a> 태그 사용 권장
+- 불필요한 div, span 사용은 지양해주세요
+        `,
+      },
+    },
+  },
+  tags: ['autodocs'],
+  excludeStories: /.*Data$/,
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: [
+        'primaryFulled',
+        'secondaryFulled',
+        'dangerFulled',
+        'primaryOutlined',
+        'secondaryOutlined',
+        'dangerOutlined',
+      ],
+      description: '버튼의 스타일 변형을 선택하세요.',
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+      description: '버튼의 크기를 선택하세요.',
+    },
+    as: {
+      control: { type: 'select' },
+      options: ['button', 'a', 'div', 'span'],
+      description: '렌더링할 HTML 요소를 선택하세요.',
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: '버튼의 비활성화 상태를 설정하세요.',
+    },
+    isFullWidth: {
+      control: 'boolean',
+      description: '버튼이 전체 너비를 차지할지 설정하세요.',
+    },
+    href: {
+      control: 'text',
+      description: 'as="a"일 때 링크 URL을 설정하세요.',
+    },
+    className: {
+      control: 'text',
+      description: '추가 CSS 클래스를 입력하세요.',
+    },
+    children: {
+      control: 'text',
+      description: '버튼 내용을 입력하세요.',
+    },
+  },
+  args: {
+    children: '버튼',
+    variant: 'primaryFulled',
+    size: 'md',
+    as: 'button',
+    isDisabled: false,
+    isFullWidth: true,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<ButtonProps>;
+
+export const PrimaryFilled: Story = {
+  args: {
+    children: 'Primary Filled',
+    variant: 'primaryFulled',
+    size: 'md',
+    as: 'button',
+  },
+};
+
+export const SecondaryFilled: Story = {
+  args: {
+    children: 'Secondary Filled',
+    variant: 'secondaryFulled',
+    size: 'md',
+    as: 'button',
+  },
+};
+
+export const DangerFilled: Story = {
+  args: {
+    children: 'Danger Filled',
+    variant: 'dangerFulled',
+    size: 'md',
+    as: 'button',
+  },
+};
+
+export const PrimaryOutlined: Story = {
+  args: {
+    children: 'Primary Outlined',
+    variant: 'primaryOutlined',
+    size: 'md',
+    as: 'button',
+  },
+};
+
+export const SecondaryOutlined: Story = {
+  args: {
+    children: 'Secondary Outlined',
+    variant: 'secondaryOutlined',
+    size: 'md',
+    as: 'button',
+  },
+};
+
+export const DangerOutlined: Story = {
+  args: {
+    children: 'Danger Outlined',
+    variant: 'dangerOutlined',
+    size: 'md',
+    as: 'button',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: 'Disabled Button',
+    variant: 'primaryFulled',
+    size: 'md',
+    as: 'button',
+    isDisabled: true,
+  },
+};
+
+export const NotFullWidth: Story = {
+  args: {
+    children: 'Not Full Width',
+    variant: 'primaryFulled',
+    size: 'md',
+    as: 'button',
+    isFullWidth: false,
+  },
+};
+
+export const AsAnchor: Story = {
+  args: {
+    children: 'Anchor Button',
+    variant: 'primaryFulled',
+    size: 'md',
+    as: 'a',
+    href: '#',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex w-full flex-col gap-4">
+      <div className="flex flex-wrap gap-2">
+        <Button variant="primaryFulled" size="md">
+          Primary Filled
+        </Button>
+        <Button variant="secondaryFulled" size="md">
+          Secondary Filled
+        </Button>
+        <Button variant="dangerFulled" size="md">
+          Danger Filled
+        </Button>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Button variant="primaryOutlined" size="md">
+          Primary Outlined
+        </Button>
+        <Button variant="secondaryOutlined" size="md">
+          Secondary Outlined
+        </Button>
+        <Button variant="dangerOutlined" size="md">
+          Danger Outlined
+        </Button>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: '모든 버튼 variants를 한번에 비교해볼 수 있습니다.',
+      },
+    },
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex w-full flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Button variant="primaryFulled" size="sm">
+          Small
+        </Button>
+        <Button variant="primaryFulled" size="md">
+          Medium
+        </Button>
+        <Button variant="primaryFulled" size="lg">
+          Large
+        </Button>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: '버튼의 모든 크기를 비교해볼 수 있습니다.',
+      },
+    },
+  },
+};
+
+export const States: Story = {
+  render: () => (
+    <div className="flex w-full flex-col gap-4">
+      <div className="flex flex-wrap gap-2">
+        <Button variant="primaryFulled" size="md">
+          Normal
+        </Button>
+        <Button variant="primaryFulled" size="md" isDisabled>
+          Disabled
+        </Button>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Button variant="primaryFulled" size="md" isFullWidth>
+          Full Width
+        </Button>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Button variant="primaryFulled" size="md" isFullWidth={false}>
+          Not Full Width
+        </Button>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: '버튼의 다양한 상태를 확인할 수 있습니다.',
+      },
+    },
+  },
+};

--- a/packages/ui/src/design-system/base-components/Button/Button.stories.tsx
+++ b/packages/ui/src/design-system/base-components/Button/Button.stories.tsx
@@ -16,7 +16,6 @@ const meta: Meta<ButtonProps> = {
 - ✅ 3가지 크기 지원 (sm, md, lg)
 - ✅ 다양한 HTML 요소로 렌더링 가능 (button, a, div, span)
 - ✅ 전체 너비 및 비활성화 상태 지원
-- ✅ TailwindCSS 동적 클래스 최적화 적용
 
 ## as prop 사용 가이드
 - **button**: 기본값, 일반적인 버튼 용도

--- a/packages/ui/src/design-system/base-components/Button/Button.tsx
+++ b/packages/ui/src/design-system/base-components/Button/Button.tsx
@@ -1,0 +1,112 @@
+import { cn } from '@/utils/cn';
+
+export interface ButtonOwnProps {
+  children: React.ReactNode;
+
+  // div, span은 react-router-dom의 <Link>와 함께 사용할 때 <a> 태그 중복 방지를 위해 사용.
+  // Next.js의 <Link>는 자식이 <a> 태그일 경우 a 요소 중복이 자동 제거됨. <a> 태그 사용 권장. 불 필요한 div, span 사용 방지.
+  as?: 'button' | 'a' | 'div' | 'span';
+
+  // 스타일 정의
+  variant:
+    | 'primaryFulled'
+    | 'secondaryFulled'
+    | 'dangerFulled'
+    | 'primaryOutlined'
+    | 'secondaryOutlined'
+    | 'dangerOutlined';
+  size: 'sm' | 'md' | 'lg';
+  className?: string;
+  isDisabled?: boolean;
+  isFullWidth?: boolean;
+}
+
+type HTMLButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+type HTMLAnchorProps = React.AnchorHTMLAttributes<HTMLAnchorElement>;
+type HTMLDivProps = React.HTMLAttributes<HTMLDivElement>;
+type HTMLSpanProps = React.HTMLAttributes<HTMLSpanElement>;
+
+export type ButtonProps =
+  | (ButtonOwnProps & { as?: 'button' } & HTMLButtonProps)
+  | (ButtonOwnProps & { as: 'a' } & HTMLAnchorProps)
+  | (ButtonOwnProps & { as: 'div' } & HTMLDivProps)
+  | (ButtonOwnProps & { as: 'span' } & HTMLSpanProps);
+
+const DEFAULT_CLASSES = 'rounded-lg flex items-center justify-center gap-x-sm';
+const SIZE_CLASSES = {
+  sm: 'font-style-small px-sm h-[32px]',
+  md: 'font-style-medium px-md h-[40px]',
+  lg: 'font-style-large px-lg h-[48px]',
+};
+const VARIANT_CLASSES = {
+  primaryFulled: 'bg-bg-primary text-text-inverse',
+  secondaryFulled: 'bg-bg-secondary text-text-inverse',
+  dangerFulled: 'bg-bg-danger text-text-inverse',
+  primaryOutlined: 'bg-white border border-border-primary text-text-primary',
+  secondaryOutlined: 'bg-white border border-border-secondary text-text-secondary',
+  dangerOutlined: 'bg-white border border-border-danger text-text-danger',
+};
+
+const Button = ({
+  as = 'button',
+  children,
+  variant,
+  size,
+  className,
+  isDisabled = false,
+  isFullWidth = true,
+  ...restprops
+}: ButtonProps) => {
+  const commonClasses = cn(
+    DEFAULT_CLASSES,
+    SIZE_CLASSES[size],
+    VARIANT_CLASSES[variant],
+    className,
+    isFullWidth && 'w-full',
+    isDisabled && 'bg-bg-disabled text-text-disabled'
+  );
+
+  if (as === 'button') {
+    const { ...buttonProps } = restprops as HTMLButtonProps;
+
+    return (
+      <button className={commonClasses} disabled={isDisabled} {...buttonProps}>
+        {children}
+      </button>
+    );
+  }
+
+  if (as === 'a') {
+    const { ...anchorProps } = restprops as HTMLAnchorProps;
+
+    return (
+      <a className={commonClasses} {...anchorProps}>
+        {children}
+      </a>
+    );
+  }
+
+  if (as === 'div') {
+    const { ...divProps } = restprops as HTMLDivProps;
+
+    return (
+      <div className={commonClasses} {...divProps}>
+        {children}
+      </div>
+    );
+  }
+
+  if (as === 'span') {
+    const { ...spanProps } = restprops as HTMLSpanProps;
+
+    return (
+      <span className={commonClasses} {...spanProps}>
+        {children}
+      </span>
+    );
+  }
+};
+
+Button.displayName = 'Button';
+
+export default Button;

--- a/packages/ui/src/design-system/base-components/Button/index.ts
+++ b/packages/ui/src/design-system/base-components/Button/index.ts
@@ -1,0 +1,1 @@
+export { default as Button } from './Button';

--- a/packages/ui/src/design-system/base-components/index.ts
+++ b/packages/ui/src/design-system/base-components/index.ts
@@ -5,3 +5,4 @@ export * from './FormMessage';
 export * from './Input';
 export * from './Label';
 export * from './Textarea';
+export * from './Button';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- UI 버튼 컴포넌트 와 스토리 생성

**주요 기능**
- 6가지 미리 정의된 variant (Primary/Secondary/Danger의 Filled/Outlined 조합)
- 3가지 크기 지원 (sm, md, lg)
- 다양한 HTML 요소로 렌더링 가능 (button, a, div, span)
- 전체 너비 및 비활성화 상태 지원

**as prop 사용 가이드**
- button: 기본값, 일반적인 버튼 용도
- a: 링크 기능이 필요한 경우
- div/span: react-router-dom의 `<Link>` 와 함께 사용할 때 태그 중복 방지를 위해 사용합니다. Next.js의 `<Link>`는 자식이 태그일 경우 a 요소 중복이 자동 제거되므로 태그 사용 권장합니다. 불필요한 div, span 사용은 지양
  - Next에서 사용할 경우
    ```
    <Link>
      <Button as="a">버튼</Button>
    </Link>
    
    // 렌더링 결과: a 요소 중복 제거
    <a>버튼</a>
    ```
  - react-router-dom에서 사용할 경우
    ```
    <Link>
      <Button as="a">버튼</Button>
    </Link>
    
    // 렌더링 결과 : a 요소 중복
    <a><a class="tailwind-style">버튼</a></a>
    
    // 사용시 
    <Link>
      <Button as="div">버튼</Button>
    </Link>
    
    // 렌더링 결과
    <a><div class="tailwind-style">버튼</div></a>
    ```

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/ad331310-7667-41e1-9c09-330a2e44efdd)
![image](https://github.com/user-attachments/assets/962a5bec-6567-4af0-aa71-4bbaa2d19cf7)
![image](https://github.com/user-attachments/assets/33d24cd8-0161-49a7-b01e-ade09bac7898)
![image](https://github.com/user-attachments/assets/5222d8ab-0715-4bbb-a023-5b449aa4dae0)



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
