### PR TITLE
[feat] 이미지 업로드 및 스토리지 관리 기능 구현

### DIFF
--- a/apps/web/app/api/images/route.ts
+++ b/apps/web/app/api/images/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { uploadToStorage, deleteFromStorage } from '@/services/images/server';
+
+import { getAuthenticatedUser } from '@/utils/auth/auth-utils';
+
+export async function POST(request: NextRequest) {
+  try {
+    // 사용자 인증 확인
+    const authResult = await getAuthenticatedUser();
+    if (!authResult.success || !authResult.userId) {
+      return NextResponse.json({ error: '로그인이 필요합니다' }, { status: 401 });
+    }
+
+    // FormData에서 파일 추출
+    const formData = await request.formData();
+    const files = formData.getAll('images') as File[];
+
+    if (files.length === 0) {
+      return NextResponse.json({ error: '업로드할 이미지를 선택해주세요' }, { status: 400 });
+    }
+
+    // 서버 서비스를 통해 이미지 업로드
+    const result = await uploadToStorage(files, authResult.userId);
+
+    // 결과 반환
+    if (!result.success && result.errors.length > 0) {
+      return NextResponse.json(
+        { error: '이미지 업로드에 실패했습니다', details: result.errors },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: `${result.uploadResults.length}개의 이미지가 업로드되었습니다`,
+      images: result.uploadResults,
+      errors: result.errors.length > 0 ? result.errors : undefined,
+    });
+  } catch (error) {
+    console.error('이미지 업로드 오류:', error);
+    return NextResponse.json({ error: '이미지 업로드 중 오류가 발생했습니다' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    // 사용자 인증 확인
+    const authResult = await getAuthenticatedUser();
+    if (!authResult.success || !authResult.userId) {
+      return NextResponse.json({ error: '로그인이 필요합니다' }, { status: 401 });
+    }
+
+    const { paths } = await request.json();
+
+    if (!Array.isArray(paths) || paths.length === 0) {
+      return NextResponse.json({ error: '삭제할 이미지 경로를 제공해주세요' }, { status: 400 });
+    }
+
+    // 서버 서비스를 통해 이미지 삭제
+    const result = await deleteFromStorage(paths, authResult.userId);
+
+    return NextResponse.json({
+      success: true,
+      message: `${result.deleteResults.length}개의 이미지가 삭제되었습니다`,
+      deletedPaths: result.deleteResults,
+      errors: result.errors.length > 0 ? result.errors : undefined,
+    });
+  } catch (error) {
+    console.error('이미지 삭제 오류:', error);
+    return NextResponse.json({ error: '이미지 삭제 중 오류가 발생했습니다' }, { status: 500 });
+  }
+}

--- a/apps/web/components/ui/ImageUpload.tsx
+++ b/apps/web/components/ui/ImageUpload.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+
+import { Icon, Thumbnail } from '@repo/ui/components';
+
+import { validateMultipleImages } from '@/lib/validations/image';
+
+import { PRODUCT_MAX_IMAGES } from '@/constants';
+
+interface ImageUploadProps {
+  onImagesChange: (images: File[]) => void;
+  maxImages?: number;
+  images: File[];
+}
+
+interface UploadedImage {
+  file: File;
+  preview: string;
+}
+
+const ImageUpload = ({
+  onImagesChange,
+  maxImages = PRODUCT_MAX_IMAGES,
+  images,
+}: ImageUploadProps) => {
+  const [uploadedImages, setUploadedImages] = useState<UploadedImage[]>([]);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const fileReadersRef = useRef<FileReader[]>([]);
+
+  const handleFiles = (files: FileList | null) => {
+    if (!files) return;
+
+    const fileArray = Array.from(files);
+    const currentImages = [...images, ...fileArray];
+
+    // 유효성 검사
+    const validation = validateMultipleImages(currentImages, maxImages);
+
+    if (!validation.valid) {
+      setErrors(validation.errors);
+      return;
+    }
+
+    // 이미지 미리보기 생성
+    const newImages: UploadedImage[] = [];
+    let completedCount = 0;
+
+    fileArray.forEach((file, index) => {
+      const reader = new FileReader();
+      fileReadersRef.current[index] = reader;
+
+      reader.onload = (e) => {
+        if (e.target?.result) {
+          newImages.push({
+            file,
+            preview: e.target.result as string,
+          });
+
+          completedCount++;
+          if (completedCount === fileArray.length) {
+            setUploadedImages((prev) => [...prev, ...newImages]);
+            onImagesChange(currentImages);
+            setErrors([]);
+          }
+        }
+      };
+
+      reader.onerror = () => {
+        setErrors((prev) => [...prev, `이미지 ${index + 1} 로드에 실패했습니다.`]);
+      };
+
+      reader.readAsDataURL(file);
+    });
+  };
+
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleFiles(e.target.files);
+  };
+
+  const removeImage = (index: number) => {
+    const newUploadedImages = uploadedImages.filter((_, i) => i !== index);
+    const newImages = images.filter((_, i) => i !== index);
+
+    // URL.revokeObjectURL로 메모리 해제
+    const removedImage = uploadedImages[index];
+    if (removedImage && removedImage.preview.startsWith('blob:')) {
+      URL.revokeObjectURL(removedImage.preview);
+    }
+
+    setUploadedImages(newUploadedImages);
+    onImagesChange(newImages);
+    setErrors([]);
+  };
+
+  const reorderImages = (fromIndex: number, toIndex: number) => {
+    const newUploadedImages = [...uploadedImages];
+    const newImages = [...images];
+
+    const draggedUploadedImage = newUploadedImages.splice(fromIndex, 1)[0];
+    const draggedImage = newImages.splice(fromIndex, 1)[0];
+
+    if (draggedUploadedImage && draggedImage) {
+      newUploadedImages.splice(toIndex, 0, draggedUploadedImage);
+      newImages.splice(toIndex, 0, draggedImage);
+
+      setUploadedImages(newUploadedImages);
+      onImagesChange(newImages);
+    }
+  };
+
+  const handleDragStart = (e: React.DragEvent, index: number) => {
+    setDraggedIndex(index);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleDrop = (e: React.DragEvent, dropIndex: number) => {
+    e.preventDefault();
+    if (draggedIndex !== null && draggedIndex !== dropIndex) {
+      reorderImages(draggedIndex, dropIndex);
+    }
+    setDraggedIndex(null);
+  };
+
+  const handleDragEnd = () => {
+    setDraggedIndex(null);
+  };
+
+  const openFileDialog = () => {
+    fileInputRef.current?.click();
+  };
+
+  // 컴포넌트 언마운트 시 메모리 정리
+  useEffect(() => {
+    return () => {
+      // FileReader 정리
+      fileReadersRef.current.forEach((reader) => {
+        if (reader.readyState === FileReader.LOADING) {
+          reader.abort();
+        }
+      });
+      fileReadersRef.current = [];
+
+      // 미리보기 이미지 URL 정리
+      uploadedImages.forEach((image) => {
+        if (image.preview.startsWith('blob:')) {
+          URL.revokeObjectURL(image.preview);
+        }
+      });
+    };
+  }, [uploadedImages]);
+
+  return (
+    <div className="space-y-4">
+      {/* 이미지 미리보기 및 업로드 버튼 */}
+      <div className="flex gap-3 select-none">
+        {uploadedImages.length < maxImages && (
+          <button
+            type="button"
+            onClick={openFileDialog}
+            className="w-16 h-16 border-2 border-dashed border-border-form rounded-lg flex flex-col items-center justify-center hover:border-border-base transition-colors flex-shrink-0 cursor-pointer mt-sm"
+          >
+            <Icon name="Photo" />
+            <span className="font-style-small">
+              {uploadedImages.length}/{maxImages}
+            </span>
+          </button>
+        )}
+        <div className="flex gap-3 overflow-x-auto min-w-0 flex-1 pt-sm">
+          {uploadedImages.map((image, index) => (
+            <div
+              key={index}
+              className={`relative flex-shrink-0 cursor-move ${
+                draggedIndex === index ? 'opacity-50' : ''
+              }`}
+              draggable
+              onDragStart={(e) => handleDragStart(e, index)}
+              onDragOver={handleDragOver}
+              onDrop={(e) => handleDrop(e, index)}
+              onDragEnd={handleDragEnd}
+            >
+              <Thumbnail
+                imgUrl={image.preview}
+                alt={`업로드된 이미지 ${index + 1}`}
+                width="w-16"
+                height="h-16"
+                aspectRatio="square"
+                rounded="sm"
+                className="border border-border-base pointer-events-none"
+              />
+              {index === 0 && (
+                <div className="absolute bottom-0 left-0 w-full bg-black/90 text-text-inverse font-style-extra-small text-center px-1 py-0.5 pointer-events-none">
+                  대표 사진
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => removeImage(index)}
+                className="absolute -top-2 -right-2 bg-bg-base rounded-full w-4 h-4 flex items-center justify-center hover:bg-black hover:text-text-inverse font-style-small pointer-events-auto cursor-pointer"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept="image/jpeg,image/jpg,image/png,image/webp"
+        onChange={handleFileInput}
+        className="hidden"
+      />
+
+      {/* 에러 메시지 */}
+      {errors.length > 0 && (
+        <div className="space-y-1">
+          {errors.map((error, index) => (
+            <p key={index} className="font-style-small text-text-error">
+              {error}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ImageUpload;

--- a/apps/web/constants/index.ts
+++ b/apps/web/constants/index.ts
@@ -1,1 +1,2 @@
 export { SPECIAL_CITIES, METROPOLITAN_CITIES } from './cities';
+export { STORAGE_BUCKET_NAME } from './storage-bucket';

--- a/apps/web/constants/index.ts
+++ b/apps/web/constants/index.ts
@@ -1,2 +1,3 @@
 export { SPECIAL_CITIES, METROPOLITAN_CITIES } from './cities';
+export { PRODUCT_MAX_IMAGES } from './product-images';
 export { STORAGE_BUCKET_NAME } from './storage-bucket';

--- a/apps/web/constants/product-images.ts
+++ b/apps/web/constants/product-images.ts
@@ -1,0 +1,1 @@
+export const PRODUCT_MAX_IMAGES = 5;

--- a/apps/web/constants/storage-bucket.ts
+++ b/apps/web/constants/storage-bucket.ts
@@ -1,0 +1,1 @@
+export const STORAGE_BUCKET_NAME = 'product-image';

--- a/apps/web/lib/storage/index.ts
+++ b/apps/web/lib/storage/index.ts
@@ -1,0 +1,1 @@
+export * from './storage';

--- a/apps/web/lib/storage/storage.ts
+++ b/apps/web/lib/storage/storage.ts
@@ -1,0 +1,62 @@
+'use server';
+
+import { supabaseServerClient } from '@/lib/supabase';
+
+import { STORAGE_BUCKET_NAME } from '@/constants';
+
+export interface UploadResult {
+  success: boolean;
+  url?: string;
+  path?: string;
+  error?: string;
+}
+
+// 서버 사이드 업로드
+export const uploadImageServer = async (file: File, path: string): Promise<UploadResult> => {
+  try {
+    const supabase = await supabaseServerClient();
+
+    const { data, error } = await supabase.storage.from(STORAGE_BUCKET_NAME).upload(path, file, {
+      upsert: false,
+      contentType: file.type,
+    });
+
+    if (error) {
+      return { success: false, error: error.message };
+    }
+
+    // 공개 URL 생성
+    const { data: urlData } = supabase.storage.from(STORAGE_BUCKET_NAME).getPublicUrl(data.path);
+
+    return {
+      success: true,
+      url: urlData.publicUrl,
+      path: data.path,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : '업로드 중 오류가 발생했습니다',
+    };
+  }
+};
+
+// 이미지 삭제
+export const deleteImage = async (path: string) => {
+  try {
+    const supabase = await supabaseServerClient();
+
+    const { error } = await supabase.storage.from(STORAGE_BUCKET_NAME).remove([path]);
+
+    if (error) {
+      return { success: false, error: error.message };
+    }
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : '삭제 중 오류가 발생했습니다',
+    };
+  }
+};

--- a/apps/web/lib/validations/image.ts
+++ b/apps/web/lib/validations/image.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+import { PRODUCT_MAX_IMAGES } from '@/constants';
+
+// 이미지 파일 유효성 검사 스키마
+export const imageFileSchema = z.object({
+  name: z.string(),
+  size: z.number().max(5 * 1024 * 1024, '이미지 크기는 5MB 이하여야 합니다'),
+  type: z
+    .string()
+    .refine(
+      (type) => ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'].includes(type),
+      '지원되는 이미지 형식: JPEG, PNG, WebP'
+    ),
+});
+
+// 다중 이미지 업로드 스키마
+export const multipleImagesSchema = z.object({
+  images: z
+    .array(imageFileSchema)
+    .min(1, '최소 1개의 이미지를 업로드해주세요')
+    .max(PRODUCT_MAX_IMAGES, `최대 ${PRODUCT_MAX_IMAGES}개의 이미지만 업로드할 수 있습니다`),
+});
+
+// 클라이언트 사이드 파일 유효성 검사
+export function validateImageFile(file: File): { valid: boolean; error?: string } {
+  try {
+    imageFileSchema.parse({
+      name: file.name,
+      size: file.size,
+      type: file.type,
+    });
+    return { valid: true };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { valid: false, error: error.errors[0]?.message || '유효하지 않은 파일입니다' };
+    }
+    return { valid: false, error: '파일 검증 중 오류가 발생했습니다' };
+  }
+}
+
+// 다중 파일 유효성 검사
+export function validateMultipleImages(
+  files: File[],
+  maxImages: number
+): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  if (files.length === 0) {
+    errors.push('최소 1개의 이미지를 업로드해주세요');
+  }
+
+  if (files.length > maxImages) {
+    errors.push(`최대 ${maxImages}개의 이미지만 업로드할 수 있습니다`);
+  }
+
+  files.forEach((file, index) => {
+    const validation = validateImageFile(file);
+    if (!validation.valid) {
+      errors.push(`이미지 ${index + 1}: ${validation.error}`);
+    }
+  });
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}

--- a/apps/web/lib/validations/index.ts
+++ b/apps/web/lib/validations/index.ts
@@ -1,0 +1,1 @@
+export * from './image';

--- a/apps/web/services/images/client/deleteImages.ts
+++ b/apps/web/services/images/client/deleteImages.ts
@@ -1,0 +1,56 @@
+import { API_ENDPOINTS } from '@/constants';
+import type { UploadedImage } from '@/types';
+
+/**
+ * 클라이언트에서 API를 통해 여러 이미지 삭제
+ */
+export const deleteImages = async (images: UploadedImage[]): Promise<void> => {
+  if (images.length === 0) return;
+
+  // 이미지 URL에서 path 추출 (Supabase 스토리지 경로)
+  const imagePaths = images
+    .map((image) => {
+      if (image.url) {
+        // URL에서 경로 부분만 추출
+        // 예: https://supabase.com/storage/v1/object/public/bucket/path/file.jpg -> path/file.jpg
+        const url = new URL(image.url);
+        const pathSegments = url.pathname.split('/');
+        const bucketIndex = pathSegments.findIndex((segment) => segment === 'product-image');
+        if (bucketIndex !== -1 && bucketIndex < pathSegments.length - 1) {
+          return pathSegments.slice(bucketIndex + 1).join('/');
+        }
+      }
+      return null;
+    })
+    .filter((path): path is string => path !== null);
+
+  if (imagePaths.length === 0) return;
+
+  try {
+    const response = await fetch(API_ENDPOINTS.IMAGES, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        paths: imagePaths,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      console.error('이미지 삭제 실패:', errorData);
+      // 삭제 실패는 로그만 남기고 에러를 던지지 않음 (상품 등록 실패 상황에서)
+    }
+  } catch (error) {
+    console.error('이미지 삭제 중 오류:', error);
+    // 네트워크 오류 등도 로그만 남기고 계속 진행
+  }
+};
+
+/**
+ * 클라이언트에서 API를 통해 단일 이미지 삭제
+ */
+export const deleteImage = async (image: UploadedImage): Promise<void> => {
+  await deleteImages([image]);
+};

--- a/apps/web/services/images/client/index.ts
+++ b/apps/web/services/images/client/index.ts
@@ -1,0 +1,2 @@
+export { uploadImages } from './uploadImages';
+export { deleteImages, deleteImage } from './deleteImages';

--- a/apps/web/services/images/client/uploadImages.ts
+++ b/apps/web/services/images/client/uploadImages.ts
@@ -1,0 +1,27 @@
+import { API_ENDPOINTS } from '@/constants';
+import type { ImageUploadResponse, UploadedImage } from '@/types';
+
+/**
+ * 클라이언트에서 API를 통해 이미지 업로드
+ */
+export const uploadImages = async (images: File[]): Promise<UploadedImage[]> => {
+  if (images.length === 0) return [];
+
+  const formData = new FormData();
+  images.forEach((image) => {
+    formData.append('images', image);
+  });
+
+  const response = await fetch(API_ENDPOINTS.IMAGES, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || '이미지 업로드에 실패했습니다');
+  }
+
+  const result: ImageUploadResponse = await response.json();
+  return result.images;
+};

--- a/apps/web/services/images/index.ts
+++ b/apps/web/services/images/index.ts
@@ -1,0 +1,2 @@
+// Client-side image services
+export * from './client';

--- a/apps/web/services/images/server/deleteFromStorage.ts
+++ b/apps/web/services/images/server/deleteFromStorage.ts
@@ -1,0 +1,36 @@
+import { deleteImage } from '@/lib/storage';
+
+/**
+ * 서버에서 직접 스토리지에서 이미지 삭제
+ */
+export const deleteFromStorage = async (paths: string[], userId: string) => {
+  const deleteResults = [];
+  const errors = [];
+
+  for (const path of paths) {
+    if (typeof path !== 'string') {
+      errors.push(`잘못된 경로 형식: ${path}`);
+      continue;
+    }
+
+    // 보안: 사용자의 폴더 내 파일만 삭제 가능하도록 검증
+    if (!path.startsWith(`products/${userId}/`)) {
+      errors.push(`권한이 없는 파일: ${path}`);
+      continue;
+    }
+
+    const deleteResult = await deleteImage(path);
+
+    if (deleteResult.success) {
+      deleteResults.push(path);
+    } else {
+      errors.push(`${path}: ${deleteResult.error}`);
+    }
+  }
+
+  return {
+    success: deleteResults.length > 0,
+    deleteResults,
+    errors,
+  };
+};

--- a/apps/web/services/images/server/index.ts
+++ b/apps/web/services/images/server/index.ts
@@ -1,0 +1,2 @@
+export { uploadToStorage } from './uploadToStorage';
+export { deleteFromStorage } from './deleteFromStorage';

--- a/apps/web/services/images/server/uploadToStorage.ts
+++ b/apps/web/services/images/server/uploadToStorage.ts
@@ -1,0 +1,50 @@
+import { uploadImageServer } from '@/lib/storage/storage';
+import { validateImageFile } from '@/lib/validations/image';
+
+import { generateImagePath } from '@/utils';
+
+/**
+ * 서버에서 직접 스토리지에 이미지 업로드
+ */
+export const uploadToStorage = async (files: File[], userId: string) => {
+  const uploadResults = [];
+  const errors = [];
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+
+    if (!file) {
+      errors.push(`이미지 ${i + 1}: 파일이 없습니다`);
+      continue;
+    }
+
+    // 파일 유효성 검사
+    const validation = validateImageFile(file);
+    if (!validation.valid) {
+      errors.push(`이미지 ${i + 1}: ${validation.error}`);
+      continue;
+    }
+
+    // 파일 경로 생성
+    const imagePath = generateImagePath(userId, file.name);
+
+    // 이미지 업로드
+    const uploadResult = await uploadImageServer(file, imagePath);
+
+    if (uploadResult.success) {
+      uploadResults.push({
+        url: uploadResult.url,
+        path: uploadResult.path,
+        originalName: file.name,
+      });
+    } else {
+      errors.push(`이미지 ${i + 1}: ${uploadResult.error}`);
+    }
+  }
+
+  return {
+    success: uploadResults.length > 0,
+    uploadResults,
+    errors,
+  };
+};

--- a/apps/web/services/index.ts
+++ b/apps/web/services/index.ts
@@ -1,1 +1,4 @@
-export * from './location';
+export * from './images';
+export * from './products';
+// Note: location services contain server-side code and should not be exported from main barrel
+// Import location services directly where needed on the server-side

--- a/apps/web/types/image.ts
+++ b/apps/web/types/image.ts
@@ -1,0 +1,9 @@
+export interface ImageUploadResponse {
+  images: UploadedImage[];
+}
+
+export interface UploadedImage {
+  url: string;
+  filename?: string;
+  size?: number;
+}

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -1,1 +1,2 @@
-export type { Location, Address } from './location';
+export type * from './location';
+export type * from './image';

--- a/apps/web/utils/image/image-utils.ts
+++ b/apps/web/utils/image/image-utils.ts
@@ -1,0 +1,6 @@
+// 파일 경로 생성 유틸리티
+export const generateImagePath = (userId: string, fileName: string) => {
+  const timestamp = Date.now();
+  const extension = fileName.split('.').pop();
+  return `products/${userId}/${timestamp}.${extension}`;
+};

--- a/apps/web/utils/image/index.ts
+++ b/apps/web/utils/image/index.ts
@@ -1,0 +1,1 @@
+export * from './image-utils';

--- a/apps/web/utils/index.ts
+++ b/apps/web/utils/index.ts
@@ -2,3 +2,4 @@ export { debounce } from './debounce';
 export * from './auth';
 export * from './location';
 export * from './error';
+export * from './image';

--- a/packages/ui/src/design-system/base-components/Icons/assets/Icons.ts
+++ b/packages/ui/src/design-system/base-components/Icons/assets/Icons.ts
@@ -2,7 +2,7 @@ import { FaAngleDown, FaAngleLeft, FaAngleRight, FaAngleUp } from 'react-icons/f
 import { GoBellFill, GoBell, GoHeartFill, GoHeart } from 'react-icons/go';
 import { BsClockFill, BsClock } from 'react-icons/bs';
 import { RxHamburgerMenu } from 'react-icons/rx';
-import { MdRefresh } from 'react-icons/md';
+import { MdRefresh, MdOutlinePhotoCamera } from 'react-icons/md';
 import { PiMagnifyingGlassBold } from 'react-icons/pi';
 
 export const ICONS = {
@@ -22,6 +22,7 @@ export const ICONS = {
   Hamburger: RxHamburgerMenu,
 
   Refresh: MdRefresh,
+  Photo: MdOutlinePhotoCamera,
 
   MagnifyingGlass: PiMagnifyingGlassBold,
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

상품 등록 시 이미지 업로드, 미리보기, 관리 기능을 구현했습니다.
- 이미지 업로드 컴포넌트
- 스토리지 관리
- 유틸리티 및 타입

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [x] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

  - 컴포넌트: ImageUpload.tsx - 메인 이미지 업로드 UI
  - API: app/api/images/route.ts - 이미지 CRUD API
  - 서비스: services/images/ - 클라이언트/서버 이미지 처리
  - 스토리지: lib/storage/ - 스토리지 연동 라이브러리
  - 타입: types/image.ts - 이미지 관련 타입 정의
  - 유틸: utils/image/ - 이미지 처리 유틸리티
  - 상수: constants/ - 이미지 관련 설정값
