### PR TITLE
[feat] 상품 상세 페이지 서비스 함수 생성 및 데이터 fetch #91

### DIFF
--- a/apps/web/app/(pages)/products/[productId]/page.tsx
+++ b/apps/web/app/(pages)/products/[productId]/page.tsx
@@ -1,3 +1,7 @@
+import { notFound } from 'next/navigation';
+
+import { fetchProductDetailWithPrisma } from '@/services/products';
+
 import {
   ProductDetailHeader,
   ProductImageCarousel,
@@ -7,35 +11,44 @@ import {
   ProductFooter,
   UserInfoLayout,
 } from '@/components/product-detail';
-import { mockProduct, mockProductImages } from './data';
 
-const ProductDetailPage = () => {
-  const images = mockProductImages.map((image) => image.image_url);
+const ProductDetailPage = async ({ params }: { params: { productId: string } }) => {
+  const productId = parseInt(params.productId);
+  const product = await fetchProductDetailWithPrisma(productId);
+
+  if (!product) {
+    return notFound();
+  }
+
+  const images = product.product_images.map((image) => image.image_url);
 
   return (
-    <div className="mx-auto w-full max-w-[375px] pb-20">
-      {' '}
+    <section className="mx-auto w-full max-w-[375px] pb-20">
       {/* 푸터 높이만큼 하단 패딩 추가 */}
       <ProductDetailHeader />
       <ProductImageCarousel images={images} />
       {/* 여기에 상품 상세 정보 컴포넌트들이 추가될 예정 */}
       <div className="p-4">
-        <ProductTitle title={mockProduct.title} />
+        <ProductTitle title={product.title} />
         <UserInfoLayout
           sellerNickname="판매자 닉네임 (목데이터)" // 실제 데이터 사용 시 mockProduct.seller_nickname 등으로 변경
           sellerAvatarUrl="https://picsum.photos/seed/seller/200/200" // 실제 데이터 사용 시 변경
         />
         <AuctionInfoLayout
-          currentPrice={mockProduct.current_price}
-          decreaseUnit={mockProduct.decrease_unit}
-          startPrice={mockProduct.start_price}
-          minPrice={mockProduct.min_price}
-          createdAt={mockProduct.created_at}
+          currentPrice={product.current_price}
+          decreaseUnit={product.decrease_unit}
+          startPrice={product.start_price}
+          minPrice={product.min_price}
+          createdAt={product.created_at}
         />
-        <ProductDescription description={mockProduct.description} />
+        <ProductDescription description={product.description} />
       </div>
-      <ProductFooter currentPrice={mockProduct.current_price} minPrice={mockProduct.min_price} createdAt={mockProduct.created_at} />
-    </div>
+      <ProductFooter
+        currentPrice={product.current_price}
+        minPrice={product.min_price}
+        createdAt={product.created_at}
+      />
+    </section>
   );
 };
 

--- a/apps/web/components/products/ProductCard.tsx
+++ b/apps/web/components/products/ProductCard.tsx
@@ -1,26 +1,46 @@
+import type { ProductBadgeStatus } from '@/types';
 import { formatRelativeTime } from '@/utils';
 
 import ProductThumb from './ProductThumb';
 
 interface ProductCardProps {
+  productId: number;
+  title: string;
   imgUrl: string;
-  name: string;
-  price: number;
-  region: string;
+  currentPrice: number;
+  status: ProductBadgeStatus;
+  viewCount?: number;
   createdAt: string;
+  region: string;
+  bidderUserId: string;
 }
 
-const ProductCard = ({ imgUrl, name, price, region, createdAt }: ProductCardProps) => {
+const ProductCard = ({
+  // productId,
+  imgUrl,
+  title,
+  currentPrice,
+  status,
+  region,
+  bidderUserId,
+  createdAt,
+}: ProductCardProps) => {
   return (
     <article
       className="bg-white flex items-center gap-md p-sm rounded-[20px]"
-      aria-label={`${name}, 경매 중, 현재가 ${price}, 지역 ${region}`}
+      aria-label={`${title}, 경매 중, 현재가 ${currentPrice}, 지역 ${region}`}
     >
-      <ProductThumb imgUrl={imgUrl} name={name} width="w-[80px]" />
+      <ProductThumb
+        imgUrl={imgUrl}
+        title={title}
+        status={status}
+        bidderUserId={bidderUserId}
+        width="w-[80px]"
+      />
 
       <section className="flex flex-col gap-sm">
-        <h3 className="font-normal text-base line-clamp-2">{name}</h3>
-        <p className="font-style-large">현재가 {price.toLocaleString()}원</p>
+        <h3 className="font-normal text-base line-clamp-2">{title}</h3>
+        <p className="font-style-large">현재가 {currentPrice.toLocaleString()}원</p>
         <p className="text-xs flex items-center gap-xs  text-text-info">
           {region}
           <i>•</i>

--- a/apps/web/components/products/ProductList.tsx
+++ b/apps/web/components/products/ProductList.tsx
@@ -18,11 +18,15 @@ const ProductList = async () => {
       {products.map((product) => (
         <li key={product.product_id}>
           <ProductCard
+            productId={product.product_id}
             imgUrl={product.image_url}
-            name={product.title}
-            price={product.current_price}
+            title={product.title}
+            currentPrice={product.current_price}
+            status={product.status}
+            viewCount={product.view_count}
             region={product.region}
             createdAt={product.created_at}
+            bidderUserId={product.bidder_user_id}
           />
         </li>
       ))}

--- a/apps/web/components/products/ProductThumb.tsx
+++ b/apps/web/components/products/ProductThumb.tsx
@@ -2,27 +2,31 @@ import { Thumbnail } from '@repo/ui/components';
 
 import { ProductBadge } from '@/components/shared';
 
+import type { ProductBadgeStatus } from '@/types';
+
 import noImage from '@/assets/images/no-image.png';
 
 interface ProductThumbProps {
+  status: ProductBadgeStatus;
   imgUrl: string;
-  name: string;
+  title: string;
+  bidderUserId?: string; // 입찰 기능 완료시 필수값으로 변경 예정
   width?: string;
   className?: string;
 }
 
-const ProductThumb = ({ imgUrl, name, width, className }: ProductThumbProps) => {
+const ProductThumb = ({ status, imgUrl, title, width, className }: ProductThumbProps) => {
   return (
     <section className="relative">
       <Thumbnail
         imgUrl={imgUrl ? imgUrl : noImage.src}
-        alt={name}
+        alt={title}
         width={width}
         className={className}
       />
 
       <ProductBadge
-        variant="live"
+        status={status}
         className="absolute top-[var(--space-xs)] left-[var(--space-xs)]"
       />
     </section>

--- a/apps/web/components/shared/ProductBadge.tsx
+++ b/apps/web/components/shared/ProductBadge.tsx
@@ -1,43 +1,44 @@
 import { Badge } from '@repo/ui/components';
 
+import type { ProductBadgeStatus } from '@/types';
 interface ProductBadgeProps {
-  variant: 'ready' | 'live' | 'success' | 'end' | 'cancel';
+  status: ProductBadgeStatus;
   className?: string;
 }
 
-const COLOR_MAP = {
-  ready: 'primary',
-  live: 'primary',
-  success: 'success',
-  end: 'disabled',
-  cancel: 'disabled',
+const MAP = {
+  READY: {
+    color: 'primary',
+    variant: 'inverted',
+    label: '경매 전',
+  },
+  ACTIVE: {
+    color: 'primary',
+    variant: 'fulled',
+    label: '경매 중',
+  },
+  SOLD: {
+    // 낙찰 상태는 SOLD 에서 SUCCESS 로 변경 예정
+    color: 'success',
+    variant: 'fulled',
+    label: '낙찰',
+  },
+  EXPIRED: {
+    color: 'disabled',
+    variant: 'fulled',
+    label: '경매 종료',
+  },
+  CANCEL: {
+    color: 'disabled',
+    variant: 'fulled',
+    label: '취소',
+  },
 } as const;
 
-const VARIANT_MAP = {
-  ready: 'inverted',
-  live: 'fulled',
-  success: 'fulled',
-  end: 'fulled',
-  cancel: 'fulled',
-} as const;
-
-const STATE_MAP = {
-  ready: '경매 전',
-  live: '경매 중',
-  success: '낙찰',
-  end: '경매 종료',
-  cancel: '취소',
-} as const;
-
-const ProductBadge = ({ variant, className }: ProductBadgeProps) => {
+const ProductBadge = ({ status, className }: ProductBadgeProps) => {
   return (
-    <Badge
-      color={COLOR_MAP[variant]}
-      size="sm"
-      variant={VARIANT_MAP[variant]}
-      className={className}
-    >
-      {STATE_MAP[variant]}
+    <Badge color={MAP[status].color} size="sm" variant={MAP[status].variant} className={className}>
+      {MAP[status].label}
     </Badge>
   );
 };

--- a/apps/web/services/products/fetchProductDetail.ts
+++ b/apps/web/services/products/fetchProductDetail.ts
@@ -1,6 +1,82 @@
-// export const fetchProductDetail = async (productId: string): Promise<Product> => {
-//   const endpoint = PRODUCTS_ENDPOINTS.DETAIL(productId);
-//   const response = await axios.get(endpoint);
+import { prisma } from '@/lib/prisma';
 
-//   return response.data;
-// };
+import type { ProductAPIResponse } from '@/types';
+
+const fetchProductDetailWithPrisma = async (
+  productId: number
+): Promise<ProductAPIResponse | null> => {
+  try {
+    const product = await prisma.products.findUnique({
+      where: {
+        product_id: BigInt(productId),
+      },
+      select: {
+        product_id: true,
+        title: true,
+        description: true,
+        start_price: true,
+        current_price: true,
+        min_price: true,
+        decrease_unit: true,
+        status: true,
+        region: true,
+        detail_address: true,
+        view_count: true,
+        created_at: true,
+        updated_at: true,
+        seller_user_id: true,
+        product_images: {
+          select: {
+            image_id: true,
+            product_id: true,
+            image_url: true,
+            image_order: true,
+            created_at: true,
+          },
+          orderBy: {
+            image_order: 'asc',
+          },
+        },
+      },
+    });
+
+    if (!product) {
+      return null;
+    }
+
+    // ProductAPIResponse 형식으로 변환
+    return {
+      product_id: parseInt(product.product_id.toString()),
+      title: product.title,
+      image_url:
+        product.product_images?.length > 0 ? (product.product_images[0]?.image_url ?? '') : '',
+      description: product.description,
+      start_price: product.start_price.toNumber(),
+      current_price: product.current_price.toNumber(),
+      min_price: product.min_price.toNumber(),
+      decrease_unit: product.decrease_unit.toNumber(),
+      status: product.status as ProductAPIResponse['status'],
+      region: product.region,
+      detail_address: product.detail_address,
+      view_count: product.view_count,
+      created_at: product.created_at.toISOString(),
+      updated_at: product.updated_at?.toISOString() || product.created_at.toISOString(),
+      seller_user_id: product.seller_user_id,
+      product_images: product.product_images.map((img) => ({
+        image_id: parseInt(img.image_id.toString()),
+        product_id: parseInt(img.product_id.toString()),
+        image_url: img.image_url,
+        image_order: img.image_order,
+        created_at: img.created_at.toISOString(),
+      })),
+    };
+  } catch (error) {
+    if (process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.error('Error fetching product detail with Prisma:', error);
+    }
+    throw new Error('Failed to fetch product detail with Prisma');
+  }
+};
+
+export { fetchProductDetailWithPrisma };

--- a/apps/web/services/products/fetchProducts.ts
+++ b/apps/web/services/products/fetchProducts.ts
@@ -1,8 +1,8 @@
 import { prisma } from '@/lib/prisma';
 
-import type { ProductsAPIResponse } from '@/types';
+import type { ProductsAPIResponse, ProductStatusSchema } from '@/types';
 
-const fetchProductsWithPrisma = async (): Promise<ProductsAPIResponse[]> => {
+const fetchProductsWithPrisma = async (): Promise<ProductsAPIResponse> => {
   try {
     const products = await prisma.products.findMany({
       select: {
@@ -40,7 +40,7 @@ const fetchProductsWithPrisma = async (): Promise<ProductsAPIResponse[]> => {
       image_url:
         product.product_images?.length > 0 ? (product.product_images[0]?.image_url ?? '') : '',
       current_price: product.current_price.toNumber(),
-      status: product.status as ProductsAPIResponse['status'],
+      status: product.status as ProductStatusSchema,
       view_count: product.view_count,
       created_at: product.created_at.toISOString(),
       region: product.region,

--- a/apps/web/types/product/api.ts
+++ b/apps/web/types/product/api.ts
@@ -3,19 +3,22 @@ export interface ProductCreationResponse {
   product_id: string;
 }
 
-export interface ProductsAPIResponse {
+export type ProductStatusSchema = 'READY' | 'ACTIVE' | 'SOLD' | 'EXPIRED' | 'CANCEL';
+export type ProductBadgeStatus = ProductStatusSchema; // 입찰 기능 완료시 Exclude<ProductStatus, 'SOLD'> | 'SUCCESS' 로 수정
+
+export interface ProductCardSchema {
   product_id: number;
   title: string;
   image_url: string;
   current_price: number;
-  status: ProductStatus;
+  status: ProductBadgeStatus;
   view_count: number;
   created_at: string;
   region: string;
   bidder_user_id: string;
 }
 
-type ProductStatus = 'READY' | 'ACTIVE' | 'SOLD' | 'EXPIRED' | 'CANCEL';
+export type ProductsAPIResponse = ProductCardSchema[];
 
 export interface ProductAPIResponse {
   product_id: number;
@@ -26,7 +29,7 @@ export interface ProductAPIResponse {
   current_price: number;
   min_price: number;
   decrease_unit: number;
-  status: ProductStatus;
+  status: ProductStatusSchema;
   region: string;
   detail_address: string;
   view_count: number;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 상품 상세페이지 fetch 서비스 함수 생성 및 상세 정보 조회 기능 구현
- 상품 상세페이지의 목데이터를 supabase fetch 데이터 적용하도록 수정
- 상품 리스트 클릭 시 상품 id 조회하도록 페이지 라우팅 적용
- product 타입 리팩토링 및 업데이트

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
