### PR TITLE
[bug] 상세페이지 레이아웃의 스크롤이 적용되지 않는 이슈 해결 #96

### DIFF
--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -3,7 +3,7 @@
 @import '@repo/ui/styles.css';
 
 html {
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

상세페이지 레이아웃의 스크롤이 적용되지 않는 이슈 해결
- 원인: global.css 의 `overflow: hidden` 떄문 -> 좌주 스크롤만 히든되도록 수정 `overflow-x: hidden` -> 수직 스크롤 영향없음

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
